### PR TITLE
copyright year updated to 2022

### DIFF
--- a/templates/Html/html.html
+++ b/templates/Html/html.html
@@ -98,7 +98,7 @@
             &lt;!DOCTYPE html &gt;
             &lt;html&gt;
             &lt;head&gt;
-            &lt;title&gt;Page Title&lt;title&gt;
+            &lt;title&gt;Page Title&lt;/title&gt;
             &lt;/head&gt;
             &lt;body&gt;
 
@@ -210,7 +210,7 @@
 
     <!-- Copyright -->
     <div class="footer-copyright text-center py-3">
-      © 2021 Copyright:
+      © 2022 Copyright:
       <a href="https://mdbootstrap.com/"> CodingEasy</a>
     </div>
     <!-- Copyright -->


### PR DESCRIPTION
- In footer section the copyright year is updated from 2021 to 2022 
- In Example section "/" is added for closing <title> tag

